### PR TITLE
Refactor Experience component to use props for experience data

### DIFF
--- a/islands/Experience.tsx
+++ b/islands/Experience.tsx
@@ -1,6 +1,3 @@
-import { getContent } from "../data/content.ts";
-import { useEffect, useState } from "preact/hooks";
-
 interface ExperienceItem {
   position: string;
   company: string;
@@ -27,18 +24,7 @@ function formatDateRange(
   return startStr && endStr ? `${startStr} – ${endStr}` : startStr || endStr;
 }
 
-export function Experience() {
-  const [experience, setExperience] = useState<ExperienceItem[]>([]);
-  useEffect(() => {
-    getContent()
-      .then((exp) => {
-        console.log(exp.experience, "<-- content");
-        setExperience(exp.experience as ExperienceItem[]);
-      })
-      .catch((error) => {
-        console.error("Error fetching content:", error);
-      });
-  }, []);
+export function Experience({ experience }: { experience: ExperienceItem[] }) {
 
   return (
     <>

--- a/islands/HomeIsland.tsx
+++ b/islands/HomeIsland.tsx
@@ -14,7 +14,7 @@ export default function HomeIsland({ content }: HomeIslandProps) {
       <h1>Welcome to My Portfolio</h1>
       <p>This is a simple portfolio page.</p>
       <Skills />
-      <Experience />
+      <Experience experience={content.experience}/>
       <Projects />
     </ContentProvider>
   );


### PR DESCRIPTION
Refactor the Experience component to accept experience data as a prop, eliminating the need for internal data fetching. Update HomeIsland to pass the experience data to the Experience component.